### PR TITLE
Add near-api to pyproject.toml to Fix quickstart.sh Dependency Issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "gitpython>=3.1.40",
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
+    "near-api>=0.1.0",
     "openai>=1.0.0",
     "prometheus-client>=0.20.0",
     "prompt_toolkit>=3.0.48",


### PR DESCRIPTION

#### **Testing Steps:**
1. Clone the repo and create a virtual environment:
   ```sh
   git clone git@github.com:jbarnes850/near-ai-agent-studio.git near-ai-agent-studio
   cd near-ai-agent-studio
   python3 -m venv venv
   source venv/bin/activate
   ```
2. Install dependencies:
   ```sh
   pip install -e .
   ```
3. Run `quickstart.sh`:
   ```sh
   ./scripts/quickstart.sh
   ```
4. The script should now run without missing dependencies.
